### PR TITLE
特定の曲でツイートが送信されない不具合を修正

### DIFF
--- a/app/src/main/java/me/siketyan/silicagel/service/NotificationService.java
+++ b/app/src/main/java/me/siketyan/silicagel/service/NotificationService.java
@@ -49,15 +49,16 @@ public class NotificationService extends NotificationListenerService {
             if (!pref.getBoolean("monitor_notifications", true)) return;
 
             final Bundle extras;
-            String title, artist, album;
+            String title = "";
+            String artist = "";
+            String album = "";
+            extras = sbn.getNotification().extras;
             try {
-                extras = sbn.getNotification().extras;
                 title = extras.getCharSequence(Notification.EXTRA_TITLE).toString();
                 artist = extras.getCharSequence(Notification.EXTRA_TEXT).toString();
                 album = extras.getCharSequence(Notification.EXTRA_SUB_TEXT).toString();
             } catch (NullPointerException e) {
                 Log.d(LOG_TAG, "[Error] Empty title, artist or album was provided.");
-                return;
             }
 
             Log.d(LOG_TAG, "[Playing] " + title + " - " + artist + " (" + album + ")");

--- a/app/src/main/java/me/siketyan/silicagel/service/NotificationService.java
+++ b/app/src/main/java/me/siketyan/silicagel/service/NotificationService.java
@@ -48,11 +48,11 @@ public class NotificationService extends NotificationListenerService {
             final SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(this);
             if (!pref.getBoolean("monitor_notifications", true)) return;
 
-            final Bundle extras;
+            final Bundle extras = sbn.getNotification().extras;
             String title = "";
             String artist = "";
             String album = "";
-            extras = sbn.getNotification().extras;
+
             try {
                 title = extras.getCharSequence(Notification.EXTRA_TITLE).toString();
                 artist = extras.getCharSequence(Notification.EXTRA_TEXT).toString();

--- a/app/src/main/java/me/siketyan/silicagel/service/NotificationService.java
+++ b/app/src/main/java/me/siketyan/silicagel/service/NotificationService.java
@@ -20,6 +20,7 @@ import twitter4j.Twitter;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.util.Calendar;
 
 public class NotificationService extends NotificationListenerService {
     private static NotificationService instance;
@@ -53,6 +54,14 @@ public class NotificationService extends NotificationListenerService {
             String artist = "";
             String album = "";
 
+            final Calendar calendar = Calendar.getInstance();
+            int year = calendar.get(Calendar.YEAR);
+            int month = calendar.get(Calendar.MONTH) + 1;
+            int day = calendar.get(Calendar.DAY_OF_MONTH);
+            int hour = calendar.get(Calendar.HOUR_OF_DAY);
+            int minute = calendar.get(Calendar.MINUTE);
+            int second = calendar.get(Calendar.SECOND);
+
             try {
                 title = extras.getCharSequence(Notification.EXTRA_TITLE).toString();
                 artist = extras.getCharSequence(Notification.EXTRA_TEXT).toString();
@@ -66,7 +75,13 @@ public class NotificationService extends NotificationListenerService {
             String tweetText = pref.getString("template", "")
                     .replaceAll("%title%", title)
                     .replaceAll("%artist%", artist)
-                    .replaceAll("%album%", album);
+                    .replaceAll("%album%", album)
+                    .replaceAll("%y%", String.format("%4d", year))
+                    .replaceAll("%m%", String.format("%2d", month))
+                    .replaceAll("%d%", String.format("%2d", day))
+                    .replaceAll("%h%", String.format("%02d", hour))
+                    .replaceAll("%i%", String.format("%02d", minute))
+                    .replaceAll("%s%", String.format("%02d", second));
 
             if (tweetText.equals(previous)) return;
             previous = tweetText;

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -5,7 +5,7 @@
     <string name="edit_template">ツイートテンプレートの編集</string>
     <string name="with_cover">アルバムアートワークを添付してツイートする</string>
     <string name="template_default" formatted="false">%title% - %artist%\n#NowPlaying #自動</string>
-    <string name="template_dialog" formatted="false">%title% - タイトル\n%artist% - アーティスト名\n%album% - アルバム名</string>
+    <string name="template_dialog" formatted="false">%title% - タイトル %artist% - アーティスト名 %album% - アルバム名 %y% - 年 %m% - 月 %d% - 日 %h% - 時 %i% - 分 %s% - 秒</string>
     <string name="twitter_authorizing">認証しています…</string>
     <string name="twitter_authorized">認証しました。</string>
     <string name="twitter_failed">認証できませんでした。</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -5,7 +5,7 @@
     <string name="edit_template">ツイートテンプレートの編集</string>
     <string name="with_cover">アルバムアートワークを添付してツイートする</string>
     <string name="template_default" formatted="false">%title% - %artist%\n#NowPlaying #自動</string>
-    <string name="template_dialog" formatted="false">%title% - タイトル %artist% - アーティスト名 %album% - アルバム名 %y% - 年 %m% - 月 %d% - 日 %h% - 時 %i% - 分 %s% - 秒</string>
+    <string name="template_dialog" formatted="false">%title% - タイトル\n%artist% - アーティスト名\n%album% - アルバム名\n%y% - 年\n%m% - 月\n%d% - 日\n%h% - 時\n%i% - 分\n%s% - 秒</string>
     <string name="twitter_authorizing">認証しています…</string>
     <string name="twitter_authorized">認証しました。</string>
     <string name="twitter_failed">認証できませんでした。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
     <string name="twitter_auth">Authorize Twitter account</string>
     <string name="edit_template">Edit template of Tweets</string>
     <string name="with_cover">Tweet with album artwork</string>
-    <string name="template_dialog" formatted="false">%title% - Title\n%artist% - Artist name\n%album% - Album name</string>
+    <string name="template_dialog" formatted="false">%title% - Title\n%artist% - Artist name\n%album% - Album name\n%y% - Year\n%m% - Month\n%d% - Day\n%h% - Hour\n%i% - Minute\n%s% - Second</string>
     <string name="template_default" formatted="false">%title% - %artist%\n#NowPlaying #Auto</string>
     <string name="twitter_authorizing">Authorizing…</string>
     <string name="twitter_authorized">Authorized your account.</string>


### PR DESCRIPTION
表題通りです。
特定の曲を再生した際、ツイートされない不具合を修正しましたのでプルリクします。

## 行う作業
- [x] 各変数について、初期化処理を実施。
- [x] Bundleの代入位置の変更。
- [x] Bundleの宣言と同時に初期化を実施。
- [x] 再生開始日時などのパラメータ提供。

