### PR TITLE
意図せず空ツイートが行われてしまう不具合を修正

### DIFF
--- a/app/src/main/java/me/siketyan/silicagel/service/NotificationService.java
+++ b/app/src/main/java/me/siketyan/silicagel/service/NotificationService.java
@@ -66,11 +66,11 @@ public class NotificationService extends NotificationListenerService {
                 title = extras.getCharSequence(Notification.EXTRA_TITLE).toString();
                 artist = extras.getCharSequence(Notification.EXTRA_TEXT).toString();
                 album = extras.getCharSequence(Notification.EXTRA_SUB_TEXT).toString();
-
-                if(title == null) return;
             } catch (NullPointerException e) {
                 Log.d(LOG_TAG, "[Error] Empty title, artist or album was provided.");
             }
+
+            if(title == null || title.isEmpty()) return;
 
             Log.d(LOG_TAG, "[Playing] " + title + " - " + artist + " (" + album + ")");
 

--- a/app/src/main/java/me/siketyan/silicagel/service/NotificationService.java
+++ b/app/src/main/java/me/siketyan/silicagel/service/NotificationService.java
@@ -66,6 +66,8 @@ public class NotificationService extends NotificationListenerService {
                 title = extras.getCharSequence(Notification.EXTRA_TITLE).toString();
                 artist = extras.getCharSequence(Notification.EXTRA_TEXT).toString();
                 album = extras.getCharSequence(Notification.EXTRA_SUB_TEXT).toString();
+
+                if(title == null) return;
             } catch (NullPointerException e) {
                 Log.d(LOG_TAG, "[Error] Empty title, artist or album was provided.");
             }


### PR DESCRIPTION
表題通りです。

## 修正点
- [x] `try-catch`ブロック構文直下にnullチェックを行う処理を実装
