### PR TITLE
Xperia Music サポート

### DIFF
--- a/app/src/main/java/me/siketyan/silicagel/service/NotificationService.java
+++ b/app/src/main/java/me/siketyan/silicagel/service/NotificationService.java
@@ -35,6 +35,7 @@ public class NotificationService extends NotificationListenerService {
     private static final String FILTER_PLAYMUSIC = "com.google.android.music";
     private static final String FILTER_SPOTIFY = "com.spotify.music";
     private static final String FILTER_AMAZON = "com.amazon.mp3";
+    private static final String FILTER_SONY_MUSIC = "com.sonyericsson.music";
 
     private static final Context APP = App.getContext();
     private static final Map<String, String> PLAYERS = new HashMap<String, String>() {
@@ -43,6 +44,7 @@ public class NotificationService extends NotificationListenerService {
             put(FILTER_PLAYMUSIC, APP.getString(R.string.google_play_music));
             put(FILTER_SPOTIFY, APP.getString(R.string.spotify));
             put(FILTER_AMAZON, APP.getString(R.string.amazon));
+            put(FILTER_SONY_MUSIC, APP.getString(R.string.sony));
         }
     };
 

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -19,7 +19,7 @@
     <string name="google_play_music">Google Play ミュージック</string>
     <string name="spotify">Spotify</string>
     <string name="amazon">Amazon Music</string>
-    <string name="sony">Sony Music</string>
+    <string name="sony">Xperia Music</string>
 
     <string name="twitter_authorizing">認証しています…</string>
     <string name="twitter_authorized">認証しました。</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -19,6 +19,7 @@
     <string name="google_play_music">Google Play ミュージック</string>
     <string name="spotify">Spotify</string>
     <string name="amazon">Amazon Music</string>
+    <string name="sony">Sony Music</string>
 
     <string name="twitter_authorizing">認証しています…</string>
     <string name="twitter_authorized">認証しました。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <string name="google_play_music">Google Play Music</string>
     <string name="spotify">Spotify</string>
     <string name="amazon">Amazon Music</string>
+    <string name="sony">Sony Music</string>
 
     <string name="twitter_authorizing">Authorizing…</string>
     <string name="twitter_authorized">Authorized your account.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,7 +19,7 @@
     <string name="google_play_music">Google Play Music</string>
     <string name="spotify">Spotify</string>
     <string name="amazon">Amazon Music</string>
-    <string name="sony">Sony Music</string>
+    <string name="sony">Xperia Music</string>
 
     <string name="twitter_authorizing">Authorizing…</string>
     <string name="twitter_authorized">Authorized your account.</string>


### PR DESCRIPTION
こんにちは。はじめまして

Xperia 純正の Sony Music アプリに対応させてみました。

Sony Music アプリはアルバム名を通知に表示しないため、アルバム名の取得ができませんでした...。

アプリはこちらです: [ミュージックアプリ](https://www.sonymobile.co.jp/myxperia/app/music/)